### PR TITLE
cancel threads in NPI_close function (issue with NPI_ClientInit/NPI_C…

### DIFF
--- a/Projects/tools/LinuxHost/ipclib/client/npi_ipc_client.c
+++ b/Projects/tools/LinuxHost/ipclib/client/npi_ipc_client.c
@@ -242,7 +242,7 @@ char npi_ipc_srsp_buf[(sizeof(npiMsgData_t))];
 // variable to store the number of received synchronous response bytes
 static int numOfReceievedSRSPbytes = 0;
 
-static pthread_t NPIThreadId;
+static pthread_t NPIThreadId[2];
 static void *npi_ipc_readThreadFunc (void *ptr);
 static void *npi_ipc_handleThreadFunc (void *ptr);
 
@@ -489,7 +489,7 @@ int NPI_ClientInit(const char *devPath)
 
     if (res == NPI_LNX_SUCCESS)
     {
-    	if (pthread_create(&NPIThreadId, NULL, npi_ipc_readThreadFunc, NULL))
+    	if (pthread_create(&NPIThreadId[0], NULL, npi_ipc_readThreadFunc, NULL))
     	{
     		// thread creation failed
     		LOG_ERROR("[NPI Client] %s(): Failed to create NPI IPC Client read thread\n", __FUNCTION__);
@@ -503,7 +503,7 @@ int NPI_ClientInit(const char *devPath)
 
     if (res == NPI_LNX_SUCCESS)
     {
-    	if (pthread_create(&NPIThreadId, NULL, npi_ipc_handleThreadFunc, NULL))
+    	if (pthread_create(&NPIThreadId[1], NULL, npi_ipc_handleThreadFunc, NULL))
     	{
     		// thread creation failed
     		LOG_ERROR("[NPI Client] Failed to create NPI IPC Client handle thread\n");
@@ -1047,6 +1047,13 @@ static void npi_ipc_delsyncres(void)
  **************************************************************************************************/
 void NPI_ClientClose(void)
 {
+	//cancel worker threads
+	pthread_cancel(NPIThreadId[0]);
+	pthread_cancel(NPIThreadId[1]);
+	//wait for cancel finish
+	pthread_join(NPIThreadId[0], NULL);
+	pthread_join(NPIThreadId[1], NULL);
+
 	// Close the NPI socket connection
 
 	close(sNPIconnected);


### PR DESCRIPTION
Hi,

I found issue with NPI_ClientInit/NPI_ClientClose/NPI_ClientInit calling sequence. Each call of NPI_ClientInit function creates new threads. I simply cancel threads in NPI_ClientClose.

b. r.
Piotr
